### PR TITLE
shortened url + redirect + updated url in documents

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -119,10 +119,14 @@ favicon: /-/fastn.com/images/favicon.svg
 - Getting Started: /setup/
   document: ftd/setup.ftd
 - Data Modelling: /ftd/data-modelling/
-  - Variables: /ftd/variables/
-  - Built-in Types: /ftd/built-in-types/
-  - `record`: /ftd/record/
-  - `or-type`: /ftd/or-type/
+  - Variables: /variables/
+    document: /ftd/variables.ftd
+  - Built-in Types: /built-in-types/
+    document: /ftd/built-in-types.ftd
+  - `record`: /record/
+    document: /ftd/record.ftd
+  - `or-type`: /or-type/
+    document: /ftd/or-type.ftd
   - `list`: /list/
     document: /ftd/list.ftd
 - `component`: /components/
@@ -133,19 +137,30 @@ favicon: /-/fastn.com/images/favicon.svg
 - Kernel Components: /kernel/
   document: /ftd/kernel.ftd
   - `ftd.document` 🚧: /ftd/document/
-  - `ftd.row`: /ftd/row/
-  - `ftd.column`: /ftd/column/
-  - `ftd.container`: /ftd/container/
-  - `ftd.text`: /ftd/text/
-  - `ftd.image`: /ftd/image/
+  - `ftd.row`: /row/
+    document: /ftd/row.ftd
+  - `ftd.column`: /column/
+    document: /ftd/column.ftd
+  - `ftd.container`: /container/
+    document: /ftd/container.ftd
+  - `ftd.text`: /text/
+    document: /ftd/text.ftd
+  - `ftd.image`: /image/
+    document: /ftd/image.ftd
   - `ftd.rive`: /rive/
     document: ftd/rive.ftd
-  - `ftd.iframe`: /ftd/iframe/
-  - `ftd.integer`: /ftd/integer/
-  - `ftd.decimal`: /ftd/decimal/
-  - `ftd.boolean`: /ftd/boolean/
-  - `ftd.code`: /ftd/code/
-  - `ftd.text-input`: /ftd/text-input/
+  - `ftd.iframe`: /iframe/
+    document: /ftd/iframe.ftd
+  - `ftd.integer`: /integer/
+    document: /ftd/integer.ftd
+  - `ftd.decimal`: /decimal/
+    document: /ftd/decimal.ftd
+  - `ftd.boolean`: /boolean/
+    document: /ftd/boolean.ftd
+  - `ftd.code`: /code/
+    document: /ftd/code.ftd
+  - `ftd.text-input`: /text-input/
+    document: /ftd/text-input.ftd
   - `ftd.checkbox`: /checkbox/
     document: ftd/checkbox.ftd
   - `ftd.desktop`: /desktop/
@@ -198,7 +213,7 @@ favicon: /-/fastn.com/images/favicon.svg
     document: ftd/web-component.ftd
 - Create `fastn` package: /create-fastn-package/
   document: author/how-to/create-fastn-package.ftd
-- Best Practices 🚧: /best-practices/
+- Best Practices: /best-practices/
   - Formatting: /formatting/
     document: /best-practices/formatting.ftd
   - Import: /import-at-top/
@@ -290,9 +305,9 @@ favicon: /-/fastn.com/images/favicon.svg
   - Part 4. Event Handling: /expander/events/
   - Part 5. Publish a package: /expander/publish/
   - Part 6. Polishing UI: /expander/polish/
-- Button with shadow: /button-using-fastn/
+- Button with shadow: /button/
   document: /expander/button.ftd
-- Create rounded border: /border-radius-in-fastn/
+- Create rounded border: /rounded-border/
   document: /expander/border-radius.ftd
 - Create clean URLs: /clean-urls/
   document: /expander/sitemap-document.ftd
@@ -367,6 +382,10 @@ favicon: /-/fastn.com/images/favicon.svg
 - Publish a package: /expander/publish/-/build/
 - Create clean URLs: /clean-urls/-/build/
   document: /expander/sitemap-document.ftd 
+- Create rounded border: /rounded-border/-/build/
+  document: /expander/border-radius.ftd
+- Using images in documents: /using-images/-/build/
+  document: /expander/imagemodule/index.ftd
 
 
 # Blog: /trizwitlabs/
@@ -378,7 +397,8 @@ favicon: /-/fastn.com/images/favicon.svg
   document: blog/philippines.ftd
 - Witty Hacks!: /wittyhacks/
   document: blog/wittyhacks.ftd
-- Ahoy, Web Components!: /blog/web-components/
+- Ahoy, Web Components!: /web-components/
+  document: /blog/web-components.ftd
 - Color Scheme: /colors/
   document: blog/show-cs.ftd
 
@@ -427,5 +447,20 @@ favicon: /-/fastn.com/images/favicon.svg
 /ftd/list/: /list/
 /discord/: https://discord.gg/eNXVBMq4xt
 /package-query/: /sql/
-/images-in-modules/: https://fastn.com/using-images/
-/images-in-modules/-/planning/: https://fastn.com/using-images/-/planning/
+/images-in-modules/: /using-images/
+/images-in-modules/-/planning/: `/using-images/-/planning/
+/ftd/variables/: /variables/
+/ftd/built-in-types/: /built-in-types/
+/ftd/record/: /record/
+/ftd/or-type/: /or-type/
+/ftd/row/: /row/
+/ftd/column/: /column/
+/ftd/container/: /container/
+/ftd/text/: /text/
+/ftd/image/: /image/
+/ftd/iframe/: /iframe/
+/ftd/integer/: /integer/
+/ftd/decimal/: /decimal/
+/ftd/boolean/: /boolean/
+/ftd/text-input/: /text-input/
+/blog/web-components/: /web-components/

--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -136,7 +136,8 @@ favicon: /-/fastn.com/images/favicon.svg
   skip: true
 - Kernel Components: /kernel/
   document: /ftd/kernel.ftd
-  - `ftd.document` 🚧: /ftd/document/
+  - `ftd.document` 🚧: /document/
+    document: /ftd/document.ftd
   - `ftd.row`: /row/
     document: /ftd/row.ftd
   - `ftd.column`: /column/
@@ -464,3 +465,4 @@ favicon: /-/fastn.com/images/favicon.svg
 /ftd/boolean/: /boolean/
 /ftd/text-input/: /text-input/
 /blog/web-components/: /web-components/
+/ftd/document/: /document/

--- a/best-practices/self-referencing.ftd
+++ b/best-practices/self-referencing.ftd
@@ -9,7 +9,7 @@ id: self-ref-validity
 While assigning values to self-referencing properties, avoid assigning the same
 value to both the self-referencing property and the referred property. 
 
-For example: [`ftd.color`](https://fastn.com/ftd/built-in-types/#ftd-color)
+For example: [`ftd.color`](/built-in-types/#ftd-color)
 
 -- ds.code: Not recommended
 lang: ftd

--- a/blog/lib.ftd
+++ b/blog/lib.ftd
@@ -796,7 +796,7 @@ and use it as template and create their own color schemes by changing the
 values inside `colors.ftd`.
 
 The variables that are defined in the `colors.ftd` are of record types as 
-shown [here](https://fastn.com/ftd/built-in-types/#ftd-color-scheme).
+shown [here](/built-in-types/#ftd-color-scheme).
 
 
 

--- a/expander/basic-ui.ftd
+++ b/expander/basic-ui.ftd
@@ -207,7 +207,7 @@ lang: ftd
 -- ds.markdown:
 if: { source == "default" }
 
-`ftd.column` documentation: [read more](https://fastn.com/ftd/column/)
+`ftd.column` documentation: [read more](/column/)
 
 -- ds.markdown:
 if: { source == "default" }
@@ -232,7 +232,7 @@ lang: ftd
 -- ds.markdown:
 if: { source == "default" }
 
-`ftd.row` documentation: [read more](https://fastn.com/ftd/row/)
+`ftd.row` documentation: [read more](/row/)
 
 
 

--- a/expander/button.ftd
+++ b/expander/button.ftd
@@ -19,10 +19,10 @@ this using `fastn`.
 To make the button we will use the concepts like: 
 - [`components`](https://fastn.com/components). 
 - To the component we will apply various properties with their respective
-  [`built-in types`](https://fastn.com/ftd/built-in-types/). 
+  [`built-in types`](/built-in-types/). 
   Some of the `Primitive Types` like `caption`, `string`, `boolean` while 
   others of the `Derived Types` like `ftd.color`, `ftd.shadow`.
-- We will use [`records`](https://fastn.com/ftd/record/) as well to 
+- We will use [`records`](/record/) as well to 
   define colors for both light and dark mode as well as shadow-color similar to 
   what we have in second button.
 - We will do `event handling` that gives **shadow** to the button `on-hover`.

--- a/expander/events.ftd
+++ b/expander/events.ftd
@@ -8,8 +8,8 @@ v: Hf7XZDP-64M
 
 -- ds.markdown:
 
-- Create a [mutable](https://fastn.com/ftd/variables/#mutable) `boolean
-variable` inside the component.
+- Create a [mutable](/variables/#mutable) `boolean variable` inside the 
+component.
 
 -- ds.code: Boolean variable
 lang: ftd

--- a/expander/hello-world.ftd
+++ b/expander/hello-world.ftd
@@ -82,7 +82,7 @@ lang: ftd
 
 -- ds.h2: `index.ftd`
 
-To print Hello World, we are using [`ftd.text`](https://fastn.com/ftd/row/)
+To print Hello World, we are using [`ftd.text`](/row/)
 section
 
 -- ds.code: Code

--- a/expander/imagemodule/index.ftd
+++ b/expander/imagemodule/index.ftd
@@ -5,7 +5,7 @@
 -- my-ds.page: How to use images in documents
 
 -- ds.markdown:
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 
 In this video we will learn how to add images in fastn documents.
 
@@ -19,8 +19,9 @@ To show how to add the images by importing assets.
 
 
 -- ds.youtube:
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 v: _yM7y_Suaio
+
 
 -- ds.image:
 if: { source == "planning" }
@@ -48,7 +49,7 @@ and web apps faster.
 -- ds.h1: Supported Image Formats
 
 `fastn` supports bunch of image file formats, checkout 
-[supported-image-formats](https://fastn.com/ftd/built-in-types/#supported-image-formats) 
+[supported-image-formats](/built-in-types/#supported-image-formats) 
 to read about it. The link is shared in the discription.
 
 
@@ -97,7 +98,7 @@ if: { source == "planning" }
 After colon we start with `$`. $ is used for reference, then assets.
 
 -- ds.markdown:
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 
 After colon we start with `$`. $ is used for reference to assets.
 
@@ -119,7 +120,7 @@ browser.
 The image is added. 
 
 -- ds.image:
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 src: $fastn-assets.files.expander.imagemodule.adding-image.gif
 
 
@@ -136,11 +137,11 @@ container.
 
 -- ds.markdown:
 
-If you have watched the video where I have explained 
-how to round the corners by using the border-property, 
-[border-radius](https://fastn.com/border-radius-in-fastn/), you know 
-that we can apply it to image also. If not, you can checkout out that video as 
-well. You can find the link in description.
+If you have watched the video where I have explained how to round the corners 
+by using the border-property, [border-radius](/rounded-border/), you know that 
+we can apply it to image also. 
+If not, you can checkout out that video as well. You can find the link in 
+description.
 
 -- ds.markdown:
 if: { source == "planning" }
@@ -156,14 +157,14 @@ if: { source == "planning" }
 src: $assets.files.images.temp.home.png
 
 -- ds.markdown:
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 
 Let's say if we add another folder `temp` inside the images folder, and put 
 this image file we are using inside it. Then we need to change the path as
 
 -- ds.code:
 lang: ftd
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 
 \-- ftd.image:
 src: $assets.files.images.temp.<image-file-name-with-extension>
@@ -202,7 +203,7 @@ fastn community on Discord.
 
 
 -- ds.markdown: 
-if: { source == "default" }
+if: { source == "default" || source == "build" }
 
 Thank you guys, keep watching these videos to learn more about fastn. 
 

--- a/ftd/document.ftd
+++ b/ftd/document.ftd
@@ -127,7 +127,7 @@ attributes](/ftd/container-root-attributes/).
 
 -- ds.h2: `title`
 
-Type: : `optional` [`caption`](/ftd/built-in-types/#caption)
+Type: : `optional` [`caption`](/built-in-types/#caption)
 
 The `title` attribute specifies the title of the document. It is displayed in
 the browser's title bar or tab. The content within the title tag is crucial for

--- a/planning/button/index.ftd
+++ b/planning/button/index.ftd
@@ -37,10 +37,10 @@ this using `fastn`.
 To make the button we will use the concepts like: 
 - [`components`](https://fastn.com/components). 
 - To the component we will apply various properties with their respective
-  [`built-in types`](https://fastn.com/ftd/built-in-types/). 
+  [`built-in types`](/built-in-types/). 
   Some of the `Primitive Types` like `caption`, `string`, `boolean` while 
   others of the `Derived Types` like `ftd.color`, `ftd.shadow`.
-- We will use [`records`](https://fastn.com/ftd/record/) as well to 
+- We will use [`records`](/record/) as well to 
   define colors for both light and dark mode as well as shadow-color similar to 
   what we have in second button.
 - We will do `event handling` that gives **shadow** to the button `on-hover`.


### PR DESCRIPTION
In this Pull Request:

- The URLs are **shortened** eg: `/ftd/row/` has been shortened with `/row/`
- Created **redirect** for all such shortened URLs
- Also, the URLs are **updated** in all such documents that have used old URL. 