### PR TITLE
fixing build issue

### DIFF
--- a/FASTN/ds.ftd
+++ b/FASTN/ds.ftd
@@ -16,7 +16,7 @@ optional body body:
 boolean sidebar: true
 optional string document-title:
 optional string document-description:
-optional ftd.raw-image-src document-image: $fastn-assets.files.images.fastn.svg
+optional ftd.raw-image-src document-image: $fastn-assets.files.images.fastn.svg.light
 optional string site-name: NULL
 optional ftd.image-src site-logo: $fastn-assets.files.images.fastn.svg
 boolean github-icon: true


### PR DESCRIPTION
fastn.com 404 issue is fixed using below image `.light` property.
optional ftd.raw-image-src document-image: $fastn-assets.files.images.fastn.svg.light