### PR TITLE
Updated live URL

### DIFF
--- a/FASTN/ds.ftd
+++ b/FASTN/ds.ftd
@@ -16,7 +16,7 @@ optional body body:
 boolean sidebar: true
 optional string document-title:
 optional string document-description:
-optional ftd.raw-image-src document-image: https://fastn.com/-/fastn.com/images/fastn-logo.png.light
+optional ftd.raw-image-src document-image: https://fastn.com/-/fastn.com/images/fastn-logo.png
 optional string site-name: NULL
 optional ftd.image-src site-logo: $fastn-assets.files.images.fastn.svg
 boolean github-icon: true


### PR DESCRIPTION
With this PR we have removed the `.light` attribute from `og-image`