### PR TITLE
Redirect from `/learn` to `/frontend/learn/`

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -852,4 +852,5 @@ skip: true
 /student-programs/ambassador-program/ambassadors/ayush-soni/: /ambassadors/ayush-soni/
 /ambassadors-program/: /ambassador-program/
 /champions-program/: /champion-program/
+/learn/: /frontend/learn/
 


### PR DESCRIPTION
Added redirect to map `/learn/` to `/frontend/learn/`. 

We have two Learn subsections, the other is `/backend/learn/`.