### PR TITLE
Fixed `FASTN/ds.ftd` component: `page-with-get-started-and-no-right-sidebar`

### DIFF
--- a/FASTN/ds.ftd
+++ b/FASTN/ds.ftd
@@ -167,10 +167,11 @@ children uis:
 optional caption title:
 optional body body:
 
--- page: fastn vs React, Angular and Javascript
+-- page: $page-with-get-started-and-no-right-sidebar.title
 sidebar: false
 right-sidebar: []
 
+$page-with-get-started-and-no-right-sidebar.body
 
 -- ftd.column:
 spacing.fixed.em: 0.8


### PR DESCRIPTION
Fixed component `page-with-get-started-and-no-right-sidebar`:

```ftd
-- component page-with-get-started-and-no-right-sidebar:
children uis:
optional caption title:
optional body body:

;; Changed `caption` and added `body` to the below page component
-- page: $page-with-get-started-and-no-right-sidebar.title
sidebar: false
right-sidebar: []

$page-with-get-started-and-no-right-sidebar.body     

-- ftd.column:
spacing.fixed.em: 0.8
width: fill-container

-- obj:
$loop$: $page-with-get-started-and-no-right-sidebar.uis as $obj

-- cl.get-started:

-- end: ftd.column

-- end: page

-- end: page-with-get-started-and-no-right-sidebar
```
