### PR TITLE
minor input code-block fix

### DIFF
--- a/content-library/compare.ftd
+++ b/content-library/compare.ftd
@@ -211,7 +211,7 @@ functional frontend applications.
 
 -- ds.rendered.input:
 
-\-- boolean $show: true
+\-- boolean $show: false
 
 \-- ftd.text: Enter mouse cursor over me
 $on-mouse-enter$: $ftd.set-bool($a = $show, v = true)


### PR DESCRIPTION
Under Compare subsection, `fastn Vs React` document, the default value of mutable variable `$show` was displaying `true` instead it should have been `false` in the rendered input code block.

Made that correction in this PR.

