### PR TITLE
/overview/ is redirected to /home/

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -982,3 +982,4 @@ skip: true
 /twitter/: https://twitter.com/fastn_stack
 /discord/: https://discord.gg/bucrdvptYd
 /instagram/: https://www.instagram.com/fastn_stack/
+/overview/: /home/


### PR DESCRIPTION
In this URL: https://fastn.com/docs/
The `Overview` hyperlink was giving Page not found. So redirected /overview/ to /home/
