### PR TITLE
Fixed issues related to fastn installation on Mac and Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # TODO: //
 # This script should be run via curl:
@@ -30,13 +30,13 @@ setup_colors() {
         FMT_ORANGE=""
         FMT_RESET=""
     else
-        FMT_RED=$(printf '\033[31m')
-        FMT_GREEN=$(printf '\033[32m')
-        FMT_YELLOW=$(printf '\033[33m')
-        FMT_BLUE=$(printf '\033[34m')
-        FMT_BOLD=$(printf '\033[1m')
-        FMT_ORANGE=$(printf '\033[38;5;208m')
-        FMT_RESET=$(printf '\033[0m')
+        FMT_RED="$(printf '\033[31m')"
+        FMT_GREEN="$(printf '\033[32m')"
+        FMT_YELLOW="$(printf '\033[33m')"
+        FMT_BLUE="$(printf '\033[34m')"
+        FMT_BOLD="$(printf '\033[1m')"
+        FMT_ORANGE="$(printf '\033[38;5;208m')"
+        FMT_RESET="$(printf '\033[0m')"
     fi
 }
 
@@ -54,8 +54,8 @@ print_fastn_logo() {
     echo "   ?&@@@@B.     :P&@@@@@&BG5YG@@@@@?.     :!YG#&@@@@@@@@@G:    ^P@@@@&^       P@@@@#?      :5&@@@@! "
     echo "   ?&@@@@B.    .Y@@@@&?:    .!&@@@@?.           ..^J#@@@@@Y.   ^P@@@@&^       P@@@@#?      :5&@@@@! "
     echo "   ?&@@@@B.    :P@@@@B:     ?#@@@@@?.  ~#@&@&Y^    :Y&@@@@Y.   :5@@@@@J:.     P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@B.     7@@@@@&B55G&&@@@@@@?.  .P@@@@@@BGPB&@@@@@B^     !&@@@@@@&P~   P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@#.      ~P&@@@@@@@B7!@@@@@J.    :Y#@@@@@@@@@@#5~        ~P&@@@@@&5   G@@@@&J      :P@@@@@! "
+    echo "   ?&@@@@B.     7@@@@@&B55G&&@@@@@@?.  .P@@@@@@BGPB&@@@@@B^     !&@@@@@@&P~   P@@@@#?      :P@@@@@! "
+    echo "   ?&@@@@#.      ~P&@@@@@@@B7!@@@@@J.    :Y#@@@@@@@@@@#5~        ~P&@@@@@&5   G@@@@&J      :B@@@@@! "
     echo "    ......         .:^~~^:.   .....         .:^~!!~^:.             .:^~~^..   ......        ......  ${FMT_RESET}"
 }
 
@@ -96,11 +96,17 @@ update_path() {
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
             return 1
         fi
+    else
+        log_message "✔ Path is already added to the shell config file: $shell_config_file"
+        return 0
     fi
 }
 
 setup() {
     print_fastn_logo
+
+    PRE_RELEASE=""
+    CONTROLLER=""
 
     # Parse arguments
     while [ $# -gt 0 ]; do
@@ -113,12 +119,12 @@ setup() {
 
     echo ""
 
-    if [[ $PRE_RELEASE ]]; then
+    if [ -n "$PRE_RELEASE" ]; then
         URL="https://api.github.com/repos/fastn-stack/fastn/releases"
         log_message "Downloading the latest pre-release binaries"
     else
         URL="https://api.github.com/repos/fastn-stack/fastn/releases/latest"
-        log_message "Downloading the latest production ready binaries"
+        log_message "Downloading the latest production-ready binaries"
     fi
 
     DESTINATION_PATH="/usr/local/bin"
@@ -127,10 +133,10 @@ setup() {
         DESTINATION_PATH=$DESTINATION_PATH
     else
         DESTINATION_PATH="${HOME}/.fastn/bin"
-        mkdir -p $DESTINATION_PATH
+        mkdir -p "$DESTINATION_PATH"
     fi
 
-    # remove temporary files from previous install attempts
+    # Remove temporary files from previous install attempts
     rm -f fastn_macos_x86_64 fastn_linux_musl_x86_64 fastn_controller_linux_musl_x86_64
 
     echo ""
@@ -139,11 +145,11 @@ setup() {
 
     echo ""
 
-    if [[ $CONTROLLER ]]; then 
+    if [ -n "$CONTROLLER" ]; then 
         curl -# -L "$URL" | grep ".*\/releases\/download\/.*\/fastn_controller_linux.*" | head -2 | cut -d : -f 2,3 | tee /dev/tty | xargs -I % curl -# -O -J -L % > /dev/null
         mv fastn_controller_linux_musl_x86_64 "${DESTINATION_PATH}/fastn"
         mv fastn_controller_linux_musl_x86_64.d "${DESTINATION_PATH}/fastn.d"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
+    elif [ "$(uname)" = "Darwin" ]; then
         curl -# -L "$URL" | grep ".*\/releases\/download\/.*\/fastn_macos.*" | head -1 | cut -d : -f 2,3 | tee /dev/tty | xargs -I % curl -# -O -J -L % > /dev/null
         mv fastn_macos_x86_64 "${DESTINATION_PATH}/fastn"
     else
@@ -155,10 +161,12 @@ setup() {
     echo ""
 
     # Check if the destination files are moved successfully before setting permissions
-    if [[ -e "${DESTINATION_PATH}/fastn" ]]; then
+    if [ -e "${DESTINATION_PATH}/fastn" ]; then
         chmod +x "${DESTINATION_PATH}/fastn"*
 
         log_message "✔ Successfully moved binaries to destination $DESTINATION_PATH"
+
+        echo ""
 
         if update_path; then
             log_message "╭────────────────────────────────────────╮"

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ update_path() {
 
     # Check if 'fastn' command exists
     if ! command_exists fastn; then
-        log_error "Failed to add '${DESTINATION_PATH}' to PATH."
+        log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
         return 1
     else 
         return 0

--- a/install.sh
+++ b/install.sh
@@ -160,9 +160,7 @@ setup() {
 
         log_message "✔ Successfully moved binaries to destination $DESTINATION_PATH"
 
-        update_path
-
-        if command_exists fastn; then
+        if update_path; then
             log_message "╭────────────────────────────────────────╮"
             log_message "│                                        │"
             log_message "│   fastn installation completed         │"
@@ -175,8 +173,6 @@ setup() {
             log_message "│                                        │"
             log_message "╰────────────────────────────────────────╯"
         else
-            log_error "Installation failed."
-        fi
     else
         log_error "Installation failed. Please check if you have sufficient permissions to install in $DESTINATION_PATH."
     fi

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ update_path() {
     if ! grep -qF "export PATH=\"\$PATH:${DESTINATION_PATH}\"" "$shell_config_file"; then
         if [ -w "$shell_config_file" ]; then
             # Add the destination path to the PATH variable in the shell config file
-            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file"
+            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
             log_message "✔ Updated the PATH variable in $shell_config_file"
         else
             # Display an error message if the shell config file is not writable

--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,7 @@ setup() {
             log_message "│   ${FMT_BLUE}https://fastn.com${FMT_RESET}                    │"
             log_message "│                                        │"
             log_message "╰────────────────────────────────────────╯"
-        else
+        fi
     else
         log_error "Installation failed. Please check if you have sufficient permissions to install in $DESTINATION_PATH."
     fi

--- a/install.sh
+++ b/install.sh
@@ -89,19 +89,19 @@ update_path() {
     if ! grep -qF "export PATH=\"\$PATH:${DESTINATION_PATH}\"" "$shell_config_file"; then
         if [ -w "$shell_config_file" ]; then
             # Add the destination path to the PATH variable in the shell config file
-            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file"
-             # Check if 'fastn' command exists
-            if ! command_exists fastn; then
-                log_error "Failed to add '${DESTINATION_PATH}' to PATH."
-                return 1
-            fi
+            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
             log_message "✔ Updated the PATH variable in $shell_config_file"
-            return 0
         else
             # Display an error message if the shell config file is not writable
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
-            return 1
         fi
+    fi
+
+    # Check if 'fastn' command exists
+    if ! command_exists fastn; then
+        return 1
+    else 
+        return 0
     fi
 }
 
@@ -165,7 +165,7 @@ setup() {
         chmod +x "${DESTINATION_PATH}/fastn"*
 
         log_message "✔ Successfully moved binaries to destination $DESTINATION_PATH"
-    
+
         if update_path; then
             log_message "╭────────────────────────────────────────╮"
             log_message "│                                        │"

--- a/install.sh
+++ b/install.sh
@@ -93,10 +93,10 @@ update_path() {
              # Check if 'fastn' command exists
             if ! command_exists fastn; then
                 log_error "Failed to add '${DESTINATION_PATH}' to PATH."
-                return 0
+                return 1
             fi
             log_message "✔ Updated the PATH variable in $shell_config_file"
-            return 1
+            return 0
         else
             # Display an error message if the shell config file is not writable
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."

--- a/install.sh
+++ b/install.sh
@@ -92,13 +92,14 @@ update_path() {
             echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
             log_message "✔ Updated the PATH variable in $shell_config_file"
         else
-            # Display an error message if the shell config file is not writable
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
+            return 1
         fi
     fi
 
     # Check if 'fastn' command exists
     if ! command_exists fastn; then
+        log_error "Failed to add '${DESTINATION_PATH}' to PATH."
         return 1
     else 
         return 0

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ update_path() {
 
     # Check if 'fastn' command exists
     if ! command_exists fastn; then
-        log_error "'fastn' is not installed or not in PATH. Please install 'fastn' first."
+        log_error "fastn could not be installed."
         return 1
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -91,18 +91,11 @@ update_path() {
             # Add the destination path to the PATH variable in the shell config file
             echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
             log_message "✔ Updated the PATH variable in $shell_config_file"
+            return 0
         else
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
             return 1
         fi
-    fi
-
-    # Check if 'fastn' command exists
-    if ! command_exists fastn; then
-        log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
-        return 1
-    else 
-        return 0
     fi
 }
 
@@ -167,7 +160,9 @@ setup() {
 
         log_message "✔ Successfully moved binaries to destination $DESTINATION_PATH"
 
-        if update_path; then
+        update_path
+
+        if command_exists fastn; then
             log_message "╭────────────────────────────────────────╮"
             log_message "│                                        │"
             log_message "│   fastn installation completed         │"
@@ -179,6 +174,8 @@ setup() {
             log_message "│   ${FMT_BLUE}https://fastn.com${FMT_RESET}                    │"
             log_message "│                                        │"
             log_message "╰────────────────────────────────────────╯"
+        else
+            log_error "Installation failed."
         fi
     else
         log_error "Installation failed. Please check if you have sufficient permissions to install in $DESTINATION_PATH."

--- a/install.sh
+++ b/install.sh
@@ -83,23 +83,25 @@ update_path() {
         shell_config_file="${HOME}/.profile"
     fi
 
+    echo ""
+
     # Check if the path is already added to the shell config file
     if ! grep -qF "export PATH=\"\$PATH:${DESTINATION_PATH}\"" "$shell_config_file"; then
         if [ -w "$shell_config_file" ]; then
             # Add the destination path to the PATH variable in the shell config file
-            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
+            echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file"
+             # Check if 'fastn' command exists
+            if ! command_exists fastn; then
+                log_error "Failed to add '${DESTINATION_PATH}' to PATH."
+                return 0
+            fi
             log_message "✔ Updated the PATH variable in $shell_config_file"
+            return 1
         else
             # Display an error message if the shell config file is not writable
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
             return 1
         fi
-    fi
-
-    # Check if 'fastn' command exists
-    if ! command_exists fastn; then
-        log_error "fastn could not be installed."
-        return 1
     fi
 }
 


### PR DESCRIPTION
Fixed issues related to fastn installation on Mac and Linux

Fixes:
- check if we have neccessary permissions for performing the installation
- check if the PATH has been correctly set or not
- better logs 