### PR TITLE
Added AmitU calendar to banner and CTA updated

### DIFF
--- a/FASTN/ds.ftd
+++ b/FASTN/ds.ftd
@@ -53,9 +53,11 @@ max-width.fixed.px: 1340
 -- ftd.ui list page.banner:
 
 -- banner.cta-banner:
-cta-text: Star us on Github 🌟
-cta-link: https://github.com/fastn-stack/fastn/
+cta-text: Book a Demo
+cta-link: https://calendly.com/amitu-fifthtry/30min
 bgcolor: $inherited.colors.cta-primary.base
+
+Want to try fastn for your company's website? 
 
 -- end: page.banner
 


### PR DESCRIPTION
We have updated default github star banner with Book a demo text with AmitU's calendar link on it.