### PR TITLE
Fix: create shell config file if it didnt already exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,12 @@ update_path() {
     fi
 
     echo ""
+    
+    # Create the shell config file if it doesn't exist
+    if [ ! -e "$shell_config_file" ]; then
+        log_message "✔ Created shell config file since it didn't already exist"
+        touch "$shell_config_file"
+    fi
 
     # Check if the path is already added to the shell config file
     if ! grep -qF "export PATH=\"\$PATH:${DESTINATION_PATH}\"" "$shell_config_file"; then
@@ -100,6 +106,11 @@ update_path() {
         log_message "✔ Path is already added to the shell config file: $shell_config_file"
         return 0
     fi
+}
+
+remove_temp_files() {
+    rm -f fastn_macos_x86_64 fastn_linux_musl_x86_64 fastn_controller_linux_musl_x86_64
+    log_message "✔ Removed temporary files"
 }
 
 setup() {
@@ -136,12 +147,10 @@ setup() {
         mkdir -p "$DESTINATION_PATH"
     fi
 
-    # Remove temporary files from previous install attempts
-    rm -f fastn_macos_x86_64 fastn_linux_musl_x86_64 fastn_controller_linux_musl_x86_64
-
     echo ""
 
-    log_message "✔ Removed temporary files"
+    # Remove temporary files from previous install attempts
+    remove_temp_files
 
     echo ""
 
@@ -184,6 +193,13 @@ setup() {
     else
         log_error "Installation failed. Please check if you have sufficient permissions to install in $DESTINATION_PATH."
     fi
+
+    echo ""
+
+    # Remove temporary files from this install attempt
+    remove_temp_files
+
+    echo ""
 }
 
 main() {


### PR DESCRIPTION
Create a shell configuration file if it doesn't already exist.

This addresses an issue raised by one of our Discord members (Username: envy.312) where, if the shell configuration file doesn't exist, instead of allowing it to fail, it will create the shell configuration file and then update it with the PATH variable.

![image](https://github.com/fastn-stack/fastn.com/assets/64768386/bea2ece0-aec2-47ad-86ee-ef236917569e)
