### PR TITLE
New redirect entry for /setup.exe/ & Updated windows installation

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -1044,3 +1044,4 @@ skip: true
 /linkedin/ -> https://www.linkedin.com/company/fastn-stack/
 /overview/ -> /home/
 /events/weekly-contest/ -> /weekly-contest/
+/setup.exe/ -> https://github.com/fastn-stack/fastn/releases/latest/download/fastn_setup.exe

--- a/author/setup/windows.ftd
+++ b/author/setup/windows.ftd
@@ -12,11 +12,10 @@ For Windows machine, there are three ways to install `fastn`.
 
 -- cbox.info: Our Recommendation
 
-On Windows, we recommend you to install `fastn` through fastn installer
-which can be found under the 
-[releases](https://github.com/fastn-stack/fastn/releases/)
-section of the official [fastn](https://github.com/fastn-stack/fastn) github 
-repository.
+On Windows, we recommend you to install `fastn` through fastn installer:
+
+To install `fastn_setup.exe`, on your browser, use the URL:  
+[https://fastn.com/setup.exe/](/setup.exe/)
 
 This is the preferred method as it only requires downloading the setup and
 installing it on your local system.
@@ -40,8 +39,7 @@ v: hCnDjhSPJLg
 
 -- ds.markdown:
 
-- Download the setup named `fastn_setup.exe`
-from the [Releases](https://github.com/fastn-stack/fastn/releases) page
+- Download the setup named [`fastn_setup.exe`](/setup.exe/)
 
 - Run the setup and follow the installation steps
 


### PR DESCRIPTION
1. Created a redirect entry:

```ftd
/setup.exe/ -> https://github.com/fastn-stack/fastn/releases/latest/download/fastn_setup.exe
```

2. Updated Windows Installation document and removed releases page hyperlink