### PR TITLE
Simplified the installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,22 +41,36 @@ setup_colors() {
 }
 
 print_fastn_logo() {
-    echo "${FMT_ORANGE}       .:~!!~^.                                                                                     "
-    echo "     7B@@@@@@@&.                                                                                    "
-    echo "   .J@@@@@@&&B?                                                .7GBBBP.                             "
-    echo "   !#@@@@&^                                                    ^P@@@@@^                             "
-    echo "..:5&@@@@#~.:.        .:~!!~^..             ..^~!!~^..       .:?B@@@@@?^:..   .::::.   .:~!~^:.     "
-    echo "5#@@@@@@@@@@@#7   .!G&@@@@@@@@@#5^       :JB@@@@@@@@@@#Y^   :P@@@@@@@@@@@&J   G@@@@G77P@@@@@@@&5^   "
-    echo "?5&@@@@@@@&&&5^  ~B@@@@@#GGB&@@@@@P.    ?&@@@@@BPPB&@@@@&Y. .?&@@@@@@@&&&G!   P@@@@&&@@@@@@@@@@@&7. "
-    echo "   J&@@@@#:     .YB&&#P^    ^P@@@@@!   .&@@@@#7    :JB&##G:    ~G@@@@&~.      P@@@@@@Y^...~P@@@@@&^ "
-    echo "   7&@@@@B.              ...!G@@@@@?.  .#@@@@@B7^..            ^5@@@@&^       P@@@@&5      :B@@@@@! "
-    echo "   ?&@@@@B.       .!JPB#&@@@@@@@@@@?.   ^5@@@@@@@@@&#GY7:      ^P@@@@&^       P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@B.     :P&@@@@@&BG5YG@@@@@?.     :!YG#&@@@@@@@@@G:    ^P@@@@&^       P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@B.    .Y@@@@&?:    .!&@@@@?.           ..^J#@@@@@Y.   ^P@@@@&^       P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@B.    :P@@@@B:     ?#@@@@@?.  ~#@&@&Y^    :Y&@@@@Y.   :5@@@@@J:.     P@@@@#?      :5&@@@@! "
-    echo "   ?&@@@@B.     7@@@@@&B55G&&@@@@@@?.  .P@@@@@@BGPB&@@@@@B^     !&@@@@@@&P~   P@@@@#?      :P@@@@@! "
-    echo "   ?&@@@@#.      ~P&@@@@@@@B7!@@@@@J.    :Y#@@@@@@@@@@#5~        ~P&@@@@@&5   G@@@@&J      :B@@@@@! "
-    echo "    ......         .:^~~^:.   .....         .:^~!!~^:.             .:^~~^..   ......        ......  ${FMT_RESET}"
+    echo $FMT_ORANGE
+    echo "      :--===--                                                                            "
+    echo "    .++++++++=                                                                            "
+    echo "    =++++=::-.                                             =++++:                         "
+    echo "   .+++++.                                                 =++++:                         "
+    echo ":--=+++++=---     .:--====--:.         .---=====-:.     ---+++++=---.  .-----  :-====-:.  "
+    echo "-++++++++++++   .=++++++++++++=.     :=++++++++++++=:   ++++++++++++.  .+++++.=+++++++++= "
+    echo "...:+++++:...  :+++++-...:=+++++.   .+++++-.  .:+++++.  ...+++++-...   .+++++++-::-=+++++-"
+    echo "   .+++++       ....      .+++++-   :+++++:.     ....      =++++:      .+++++-      -++++="
+    echo "   .+++++          .:---=+++++++-    -+++++++==--.         =++++:      .+++++.      :++++="
+    echo "   .+++++      .-=+++++==--+++++-     .:-==++++++++=-.     =++++:      .+++++.      :++++="
+    echo "   .+++++     .+++++:      =++++-            .:-++++++     =++++:      .+++++.      :++++="
+    echo "   .+++++     .++++=      :+++++-   -----:      :+++++     =++++:      .+++++.      :++++="
+    echo "   .+++++      +++++-:::-=+=++++-   .=++++=-::-=++++=:     -+++++==-   .+++++.      :++++="
+    echo "   .+++++       -++++++++-.-++++-     .=++++++++++-:        =+++++++:  .+++++.      :++++="
+    echo $FMT_RESET
+}
+
+print_success_box() {
+    log_message "╭────────────────────────────────────────╮"
+    log_message "│                                        │"
+    log_message "│   fastn installation completed         │"
+    log_message "│                                        │"
+    log_message "│   Restart your terminal to apply       │"
+    log_message "│   the changes.                         │"
+    log_message "│                                        │"
+    log_message "│   Get started with fastn at:           │"
+    log_message "│   ${FMT_BLUE}https://fastn.com${FMT_RESET}                    │"
+    log_message "│                                        │"
+    log_message "╰────────────────────────────────────────╯"
 }
 
 # Function for logging informational messages
@@ -87,7 +101,6 @@ update_path() {
     
     # Create the shell config file if it doesn't exist
     if [ ! -e "$shell_config_file" ]; then
-        log_message "✔ Created shell config file since it didn't already exist"
         touch "$shell_config_file"
     fi
 
@@ -96,25 +109,30 @@ update_path() {
         if [ -w "$shell_config_file" ]; then
             # Add the destination path to the PATH variable in the shell config file
             echo "export PATH=\"\$PATH:${DESTINATION_PATH}\"" >> "$shell_config_file" &&
-            log_message "✔ Updated the PATH variable in $shell_config_file"
             return 0
         else
             log_error "Failed to add '${DESTINATION_PATH}' to PATH. Insufficient permissions for '$shell_config_file'."
             return 1
         fi
     else
-        log_message "✔ Path is already added to the shell config file: $shell_config_file"
         return 0
     fi
 }
 
 remove_temp_files() {
     rm -f fastn_macos_x86_64 fastn_linux_musl_x86_64 fastn_controller_linux_musl_x86_64
-    log_message "✔ Removed temporary files"
+}
+
+# Function to handle Ctrl+C
+exit_on_interrupt() {
+    log_error "Installation interrupted."
+    remove_temp_files
+    exit 1
 }
 
 setup() {
-    print_fastn_logo
+    # Trap Ctrl+C and call the exit_on_interrupt function
+    trap exit_on_interrupt INT
 
     PRE_RELEASE=""
     CONTROLLER=""
@@ -128,23 +146,21 @@ setup() {
             --version=*) VERSION="${1#*=}" ;;
             *) echo "Unknown CLI argument: $1"; exit 1 ;;
         esac
-    shift
+        shift
     done
 
     if [ -n "$VERSION" ]; then
         echo "Installing fastn version: $VERSION"
     fi
 
-    echo ""
-
     if [ -n "$PRE_RELEASE" ]; then
-        URL="https://api.github.com/repos/fastn-stack/fastn/releases"
+        URL="https://github.com/fastn-stack/fastn/releases/latest/download"
         log_message "Downloading the latest pre-release binaries"
     elif [ -n "$VERSION" ]; then
-        URL="https://api.github.com/repos/fastn-stack/fastn/releases/tags/$VERSION"
+        URL="https://github.com/fastn-stack/fastn/releases/download/$VERSION"
         log_message "Downloading fastn release $VERSION binaries"
     else
-        URL="https://api.github.com/repos/fastn-stack/fastn/releases/latest"
+        URL="https://github.com/fastn-stack/fastn/releases/latest/download"
         log_message "Downloading the latest production-ready binaries"
     fi
 
@@ -157,66 +173,56 @@ setup() {
         mkdir -p "$DESTINATION_PATH"
     fi
 
-    echo ""
-
     # Remove temporary files from previous install attempts
     remove_temp_files
 
-    echo ""
-
-    if [ -n "$CONTROLLER" ]; then 
-        curl -# -L "$URL" | grep ".*\/releases\/download\/.*\/fastn_controller_linux.*" | head -2 | cut -d : -f 2,3 | tee /dev/tty | xargs -I % curl -# -O -J -L % > /dev/null
-        mv fastn_controller_linux_musl_x86_64 "${DESTINATION_PATH}/fastn"
-        mv fastn_controller_linux_musl_x86_64.d "${DESTINATION_PATH}/fastn.d"
-    elif [ "$(uname)" = "Darwin" ]; then
-        curl -# -L "$URL" | grep ".*\/releases\/download\/.*\/fastn_macos.*" | head -1 | cut -d : -f 2,3 | tee /dev/tty | xargs -I % curl -# -O -J -L % > /dev/null
-        mv fastn_macos_x86_64 "${DESTINATION_PATH}/fastn"
+    if [ -n "$CONTROLLER" ]; then
+        if [ "$(uname)" = "Darwin" ]; then
+            FILENAME="fastn_controller_macos_x86_64"
+        else
+            FILENAME="fastn_controller_linux_musl_x86_64"
+        fi
     else
-        curl -# -L "$URL" | grep ".*\/releases\/download\/.*\/fastn_linux.*" | head -2 | cut -d : -f 2,3 | tee /dev/tty | xargs -I % curl -# -O -J -L % > /dev/null
-        mv fastn_linux_musl_x86_64 "${DESTINATION_PATH}/fastn"
-        mv fastn_linux_musl_x86_64.d "${DESTINATION_PATH}/fastn.d"
+        if [ "$(uname)" = "Darwin" ]; then
+            FILENAME="fastn_macos_x86_64"
+        else
+            FILENAME="fastn_linux_musl_x86_64"
+        fi
     fi
 
-    echo ""
+    # Download the binary directly using the URL
+    curl -# -L -o "${DESTINATION_PATH}/fastn" "${URL}/${FILENAME}"
+    chmod +x "${DESTINATION_PATH}/fastn"
+
+    if [ -n "$CONTROLLER" ]; then
+        if [ "$(uname)" = "Darwin" ]; then
+            FILENAME="fastn_controller_macos_x86_64.d"
+        else
+            FILENAME="fastn_controller_linux_musl_x86_64.d"
+        fi
+        curl -# -L -o "${DESTINATION_PATH}/fastn.d" "${URL}/${FILENAME}"
+    fi
 
     # Check if the destination files are moved successfully before setting permissions
     if [ -e "${DESTINATION_PATH}/fastn" ]; then
-        chmod +x "${DESTINATION_PATH}/fastn"*
-
-        log_message "✔ Successfully moved binaries to destination $DESTINATION_PATH"
-
-        echo ""
-
         if update_path; then
-            log_message "╭────────────────────────────────────────╮"
-            log_message "│                                        │"
-            log_message "│   fastn installation completed         │"
-            log_message "│                                        │"
-            log_message "│   Restart your terminal to apply       │"
-            log_message "│   the changes.                         │"
-            log_message "│                                        │"
-            log_message "│   Get started with fastn at:           │"
-            log_message "│   ${FMT_BLUE}https://fastn.com${FMT_RESET}                    │"
-            log_message "│                                        │"
-            log_message "╰────────────────────────────────────────╯"
+            print_success_box
         fi
     else
         log_error "Installation failed. Please check if you have sufficient permissions to install in $DESTINATION_PATH."
     fi
 
-    echo ""
-
     # Remove temporary files from this install attempt
     remove_temp_files
-
-    echo ""
 }
+
 
 main() {
     setup_colors
+    print_fastn_logo
 
     if ! command_exists curl; then
-        echo "${FMT_RED}curl not found. Please install curl and execute the script once again${FMT_RESET}"
+        log_error "curl not found. Please install curl and execute the script once again"
         exit 1
     fi
     setup "$@"


### PR DESCRIPTION
Simplified the installation script:

Simplifications:
- Use direct browser download URLs instead of using Github API and grep
- Use minimal branding in terminal
- removed unneccessary log messages, instead use error logs for debugging

Fixes:
- Handle exit on interruption (CTRL+C)