### PR TITLE
removed redundant code 

### DIFF
--- a/ftd/video.ftd
+++ b/ftd/video.ftd
@@ -168,7 +168,6 @@ A Boolean attribute that indicates the default setting of the audio contained in
 
 \-- ftd.video: https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
 muted: true ;; <hl>
-muted: true ;; <hl>
 controls: true
 autoplay: true
 autoplay: true


### PR DESCRIPTION
Removed the third line `muted: true ;; <hl>` (already in line 2) in the `rendered.input` under `Muted` heading

![image](https://github.com/fastn-stack/fastn.com/assets/118595104/8f9fa85f-67aa-478f-9ca1-80c7e4d5edd7)