### PR TITLE
added cache dir in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,14 @@ Cargo.lock
 .packages/
 .DS_Store
 _*
+
+
+
+
+
+####### TEMPORARY FIX FOR CACHE FILES ###########
+####### FOR NANDHINI's SYSTEM ##############
+_Users_E.KRITHIKA_OneDrive_Desktop_fastn.com/fastn.com_
+_Users_E.KRITHIKA_OneDrive_Desktop_fastn.com/fastn.com_utils
+_Users_E.KRITHIKA_OneDrive_Desktop_fastn.com/fastn.com_content-library
+_Users_E.KRITHIKA_OneDrive_Desktop_fastn.com/fastn.com_FASTN_ds


### PR DESCRIPTION
added cache dir in .gitignore to prevent unneccessary cache files from being added in the commit. these cache folder/file names are unique for each system, and this PR only adds the ignores for Nandhini's system.