### PR TITLE
fix: consistent use of /custom-urls/

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -683,7 +683,7 @@ skip: true
     document: ftd-host/package-query.ftd
   - Reading JSON: /get-data/
     document: ftd-host/get-data.ftd
-- Custom URLs: /custom-url/
+- Custom URLs: /custom-urls/
   document: backend/custom-urls.ftd
 - Redirects: /redirects/-/backend/
   document: backend/redirects.ftd

--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -1070,3 +1070,4 @@ skip: true
 /linkedin/ -> https://www.linkedin.com/company/fastn-stack/
 /r/counter/ -> https://replit.com/@ajit6/counter/
 /r/acme/ -> https://replit.com/@ayushipujaa/acme/
+/custom-url/ -> /custom-urls/

--- a/content-library/index.ftd
+++ b/content-library/index.ftd
@@ -5188,7 +5188,7 @@ user accessibility and visual presentation of your website.
 -- article-record: SEO
 image: $fastn-assets.files.images.landing.seo.png
 
-fastn provides custom [URL customization](https://fastn.com/custom-url/), from 
+fastn provides custom [URL customization](https://fastn.com/custom-urls/), from 
 clean and organized links to [dynamic](https://fastn.com/dynamic-urls/) options. 
 You can also fine-tune [meta information](https://fastn.com/seo-meta/), add 
 OG-image, and manage [URL redirection](https://fastn.com/redirects/).

--- a/why/geeks.ftd
+++ b/why/geeks.ftd
@@ -633,7 +633,7 @@ the "main module".
 
 If we are rendering `foo.ftd`, e.g. by accessing `/foo/` we do folder based
 routing (we also do [dynamic routing](/dynamic-urls/) and [custom
-routes](/custom-url/) etc btw), the "module level UI" `ftd.integer` would be
+routes](/custom-urls/) etc btw), the "module level UI" `ftd.integer` would be
 constructed, and since that is the only module level UI, that is only UI user
 will see on `/foo/`.
 


### PR DESCRIPTION
Link to `/custom-urls/` in https://fastn.com/dynamic-urls/ (first paragraph) is broken as it's `/custom-url/` in FASTN.ftd. This fixes this and uses `/custom-urls` in all places.