### PR TITLE
minor footer layout fixes

### DIFF
--- a/content-library/index.ftd
+++ b/content-library/index.ftd
@@ -4614,7 +4614,7 @@ optional ftd.resizing max-width:
 -- ftd.column:
 background.solid: $inherited.colors.background.base
 width: fill-container
-padding-top.px: 42
+/padding-top.px: 42
 align-content: center
 align-self: center
 spacing.fixed.px: 7
@@ -4625,7 +4625,7 @@ max-width.fixed.px if { !footer-desktop.full-width }: $footer-desktop.max-width
 
 -- ftd.row:
 width: fill-container
-spacing: space-between
+spacing: space-around
 padding-vertical.px: 50
 padding-right.px: 48
 


### PR DESCRIPTION
# Original Footer 

## Windowed View 
<img width="1331" alt="Screenshot 2023-11-12 at 7 48 24 PM" src="https://github.com/fastn-stack/fastn.com/assets/106665190/918e7d62-c677-473f-a6bb-9a421729487e">

Fullscreen View 
<img width="1438" alt="Screenshot 2023-11-12 at 7 49 00 PM" src="https://github.com/fastn-stack/fastn.com/assets/106665190/98e0f7c5-9489-44f7-a201-cb51fe72dacf">

# After changes 

## Windowed View 
<img width="1330" alt="Screenshot 2023-11-12 at 7 50 26 PM" src="https://github.com/fastn-stack/fastn.com/assets/106665190/9ea295a4-c211-4f53-8407-f0eaf6c376d2">

## Fullscreen View
<img width="1437" alt="Screenshot 2023-11-12 at 7 50 44 PM" src="https://github.com/fastn-stack/fastn.com/assets/106665190/a11a8e1a-4258-400b-83d6-3b9ea2aef67d">
